### PR TITLE
Skip events that are `working location` spec.

### DIFF
--- a/dbinit.go
+++ b/dbinit.go
@@ -77,7 +77,7 @@ func dbInit() {
 	}
 
 	if dbVersion == 2 {
-		_, err = db.Exec(`ALTER TABLE blocker_events ADD COLUMN origin_calendar_id, TEXT`)
+		_, err = db.Exec(`ALTER TABLE blocker_events ADD COLUMN origin_calendar_id TEXT`)
 		if err != nil {
 			log.Fatalf("Error adding origin_calendar_id column to blocker_events table: %v", err)
 		}

--- a/sync.go
+++ b/sync.go
@@ -89,6 +89,10 @@ func syncCalendar(db *sql.DB, calendarService *calendar.Service, calendarID stri
 
 		for _, event := range events.Items {
 			allEventsId[event.Id] = true
+			// Google marks "working locations" as events, but we don't want to sync them
+			if event.EventType == "workingLocation" {
+				continue
+			}
 			if !strings.Contains(event.Summary, "O_o") {
 				fmt.Printf("    ✨ Syncing event: %s\n", event.Summary)
 				for otherAccountName, calendarIDs := range calendars {


### PR DESCRIPTION
When one marks a "working location" in Google calendar an event with `EventType` `"workingLocation"` is created that looks like a normal "all day" event. It is very unlikely that this is something that needs to be synced across various calendars.

+ fixing a small typo in `dbinit.go`