### PR TITLE
Deleted events fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ To sync your calendars, run the `gcalsync sync` command. The program will retrie
 
 To desync your calendars and remove all blocker events, run the `gcalsync desync` command. The program will retrieve the blocker event details from the local database and remove the corresponding events from the respective calendars.
 
+### 📋 Listing Calendars
+
+To list all calendars that have been added to the local database, run the `gcalsync list` command. The program will display the account name and calendar ID for each calendar.
+
+### 🎗️ Disabling Reminders
+
+By default blocker events will inherit your default Google Calendar reminder/alert settings (typically – 10 minutes before the event). If you *do not want* to receive reminders for the blocker events, you can disable them by setting the `disable_reminders` field to `true` in the `.gcalsync.toml` configuration file.
+
 ## 🤝 Contributing
 
 Contributions are welcome! If you encounter any issues or have suggestions for improvement, please open an issue or submit a pull request. Let's make gcalsync even better together! 💪

--- a/common.go
+++ b/common.go
@@ -20,8 +20,9 @@ import (
 )
 
 type Config struct {
-	ClientID     string `toml:"client_id"`
-	ClientSecret string `toml:"client_secret"`
+	ClientID         string `toml:"client_id"`
+	ClientSecret     string `toml:"client_secret"`
+	DisableReminders bool   `toml:"disable_reminders"`
 }
 
 var oauthConfig *oauth2.Config

--- a/dbinit.go
+++ b/dbinit.go
@@ -77,7 +77,7 @@ func dbInit() {
 	}
 
 	if dbVersion == 2 {
-		_, err = db.Exec(`ALTER TABLE blocker_events ADD COLUMN origin_calendar_id, TEXT`)
+		_, err = db.Exec(`ALTER TABLE blocker_events ADD COLUMN origin_calendar_id TEXT`)
 		if err != nil {
 			log.Fatalf("Error adding origin_calendar_id column to blocker_events table: %v", err)
 		}

--- a/sync.go
+++ b/sync.go
@@ -172,7 +172,7 @@ func syncCalendar(db *sql.DB, calendarService *calendar.Service, calendarID stri
 	}
 
 	// Delete blocker events that not exists from this calendar in other calendars
-	fmt.Printf("    🗑 Deleting blocker events that not exists in calendar %s from other calendars\n", calendarID)
+	fmt.Printf("    🗑 Deleting blocker events that no longer exist in calendar %s from other calendars…\n", calendarID)
 	for otherAccountName, calendarIDs := range calendars {
 		for _, otherCalendarID := range calendarIDs {
 			if otherCalendarID != calendarID {
@@ -196,7 +196,7 @@ func syncCalendar(db *sql.DB, calendarService *calendar.Service, calendarID stri
 
 						res, err := calendarService.Events.Get(calendarID, originEventID).Do()
 						if err != nil || res == nil || res.Status == "cancelled" {
-							fmt.Printf(" Event marked for deletion: %s\n", eventID)
+							fmt.Printf("    🚩 Event marked for deletion: %s\n", eventID)
 							eventsToDelete = append(eventsToDelete, eventID)
 						}
 					}
@@ -218,7 +218,11 @@ func syncCalendar(db *sql.DB, calendarService *calendar.Service, calendarID stri
 					if !alreadyDeleted {
 						err = otherCalendarService.Events.Delete(otherCalendarID, eventID).Do()
 						if err != nil {
-							log.Fatalf("Error deleting blocker event: %v", err)
+							if res.Status != "cancelled" {
+								log.Fatalf("Error deleting blocker event: %v", err)
+							} else {
+								fmt.Printf("     ❗️ Event already deleted in the other calendar: %s\n", eventID)
+							}
 						}
 					}
 					_, err = db.Exec("DELETE FROM blocker_events WHERE event_id = ?", eventID)

--- a/sync.go
+++ b/sync.go
@@ -89,6 +89,10 @@ func syncCalendar(db *sql.DB, calendarService *calendar.Service, calendarID stri
 
 		for _, event := range events.Items {
 			allEventsId[event.Id] = true
+			// Google marks "working locations" as events, but we don't want to sync them
+			if event.EventType == "workingLocation" {
+				continue
+			}
 			if !strings.Contains(event.Summary, "O_o") {
 				fmt.Printf("    ✨ Syncing event: %s\n", event.Summary)
 				for otherAccountName, calendarIDs := range calendars {


### PR DESCRIPTION
Minor fixes to handling of deleted events. For events that were removed manually API does not return HTTP 410, but sets event status to "cancelled".
A bit of beautification of output and a small _grammar nazi_ 😈  fix to progress report