### PR TITLE
Small fixes to deletion logic

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -172,7 +172,7 @@ func syncCalendar(db *sql.DB, calendarService *calendar.Service, calendarID stri
 	}
 
 	// Delete blocker events that not exists from this calendar in other calendars
-	fmt.Printf("    🗑 Deleting blocker events that not exists in calendar %s from other calendars\n", calendarID)
+	fmt.Printf("    🗑 Deleting blocker events that no longer exist in calendar %s from other calendars…\n", calendarID)
 	for otherAccountName, calendarIDs := range calendars {
 		for _, otherCalendarID := range calendarIDs {
 			if otherCalendarID != calendarID {
@@ -196,7 +196,7 @@ func syncCalendar(db *sql.DB, calendarService *calendar.Service, calendarID stri
 
 						res, err := calendarService.Events.Get(calendarID, originEventID).Do()
 						if err != nil || res == nil || res.Status == "cancelled" {
-							fmt.Printf(" Event marked for deletion: %s\n", eventID)
+							fmt.Printf("    🚩 Event marked for deletion: %s\n", eventID)
 							eventsToDelete = append(eventsToDelete, eventID)
 						}
 					}
@@ -218,7 +218,11 @@ func syncCalendar(db *sql.DB, calendarService *calendar.Service, calendarID stri
 					if !alreadyDeleted {
 						err = otherCalendarService.Events.Delete(otherCalendarID, eventID).Do()
 						if err != nil {
-							log.Fatalf("Error deleting blocker event: %v", err)
+							if res.Status != "cancelled" {
+								log.Fatalf("Error deleting blocker event: %v", err)
+							} else {
+								fmt.Printf("     ❗️ Event already deleted in the other calendar: %s\n", eventID)
+							}
 						}
 					}
 					_, err = db.Exec("DELETE FROM blocker_events WHERE event_id = ?", eventID)


### PR DESCRIPTION
Only add part related to deleted vs. cancelled events
When the original event is deleted API does not return HTTP 410. However, the event has status "cancelled" – or so it appears.