### PR TITLE
Make it less verbose

### DIFF
--- a/common.go
+++ b/common.go
@@ -20,11 +20,24 @@ import (
 )
 
 type Config struct {
-	ClientID         string `toml:"client_id"`
-	ClientSecret     string `toml:"client_secret"`
-	DisableReminders bool   `toml:"disable_reminders"`
-	VerbosityLevel   int    `toml:"verbosity_level"`
+	ClientID         string          `toml:"client_id"`
+	ClientSecret     string          `toml:"client_secret"`
+	DisableReminders bool            `toml:"disable_reminders"`
+	VerbosityLevel   verbosityLevels `toml:"verbosity_level"`
 }
+
+type verbosityLevels int
+
+const (
+	criticalOnly      verbosityLevels = iota // 0 - no output, other than creitical errors
+	calendarOnly                             // 1 - only list calendars being synced
+	eventsAddUpdate                          // 2 - list events being synced
+	blockCreateDelete                        // 3 - report on blocker events created/deleted
+	skipOnDelete                             // 4 - report on blocker events skipped
+	tellMeEverything                         // 5 - report everything
+)
+
+var verbosityLevel verbosityLevels
 
 var oauthConfig *oauth2.Config
 var configDir string
@@ -182,15 +195,9 @@ func tokenExpired(db *sql.DB, accountName string, calendarService *calendar.Serv
 	return calendarService
 }
 
-func printVerbosely(verbosity int, format string, a ...interface{}) {
+func printVerbosely(verbosity verbosityLevels, format string, a ...interface{}) {
 	// Print only if verbosity is higher than verbosityLevel
 	// verbosityLevel is set in the config file
-	// 0 - no output, other than creitical errors
-	// 1 - only list calendars being synced
-	// 2 - list events being synced
-	// 3 - report on blocker events created/deleted
-	// 4 - report on blocker events skipped
-	// 5 - report everything
 	if verbosity <= verbosityLevel {
 		fmt.Printf(format, a...)
 	}

--- a/common.go
+++ b/common.go
@@ -23,6 +23,7 @@ type Config struct {
 	ClientID         string `toml:"client_id"`
 	ClientSecret     string `toml:"client_secret"`
 	DisableReminders bool   `toml:"disable_reminders"`
+	VerbosityLevel   int    `toml:"verbosity_level"`
 }
 
 var oauthConfig *oauth2.Config
@@ -53,6 +54,8 @@ func readConfig(filename string) (*Config, error) {
 	if err := toml.Unmarshal(data, &config); err != nil {
 		return nil, err
 	}
+
+	verbosityLevel = config.VerbosityLevel
 
 	return &config, nil
 }
@@ -177,4 +180,18 @@ func tokenExpired(db *sql.DB, accountName string, calendarService *calendar.Serv
 	}
 
 	return calendarService
+}
+
+func printVerbosely(verbosity int, format string, a ...interface{}) {
+	// Print only if verbosity is higher than verbosityLevel
+	// verbosityLevel is set in the config file
+	// 0 - no output, other than creitical errors
+	// 1 - only list calendars being synced
+	// 2 - list events being synced
+	// 3 - report on blocker events created/deleted
+	// 4 - report on blocker events skipped
+	// 5 - report everything
+	if verbosity <= verbosityLevel {
+		fmt.Printf(format, a...)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -6,8 +6,6 @@ import (
 	"os"
 )
 
-var verbosityLevel int
-
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Println("Usage: gcalsync (add|sync|desync|list)")

--- a/main.go
+++ b/main.go
@@ -6,6 +6,8 @@ import (
 	"os"
 )
 
+var verbosityLevel int
+
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Println("Usage: gcalsync (add|sync|desync|list)")

--- a/sync.go
+++ b/sync.go
@@ -197,7 +197,7 @@ func syncCalendar(db *sql.DB, calendarService *calendar.Service, calendarID stri
 
 						res, err := calendarService.Events.Get(calendarID, originEventID).Do()
 						if err != nil || res == nil || res.Status == "cancelled" {
-							printVerbosely(4, "     x Event marked for deletion: %s\n", eventID)
+							printVerbosely(blockCreateDelete, "     x Event marked for deletion: %s\n", eventID)
 							eventsToDelete = append(eventsToDelete, eventID)
 						}
 					}
@@ -227,7 +227,7 @@ func syncCalendar(db *sql.DB, calendarService *calendar.Service, calendarID stri
 						log.Fatalf("Error deleting blocker event from database: %v", err)
 					}
 
-					printVerbosely(4, "    ❗️ ✅ Blocker event deleted: %s\n", res.Summary)
+					printVerbosely(skipOnDelete, "    ❗️ ✅ Blocker event deleted: %s\n", res.Summary)
 				}
 			}
 		}


### PR DESCRIPTION
This adds "verbosity levels" to `gcalsync` output by wrapping the progress report `fmt.Printf`s and adding a parameter to config to set comfortable verbosity. Only `fmt.Printf`s are covered, none of the `log.*`.