### PR TITLE
Support for configurable visibility of sycned events

### DIFF
--- a/common.go
+++ b/common.go
@@ -23,6 +23,7 @@ type Config struct {
 	ClientID         string `toml:"client_id"`
 	ClientSecret     string `toml:"client_secret"`
 	DisableReminders bool   `toml:"disable_reminders"`
+	EventVisibility  string `toml:"block_event_visibility"`
 }
 
 var oauthConfig *oauth2.Config

--- a/sync.go
+++ b/sync.go
@@ -19,6 +19,7 @@ func syncCalendars() {
 		log.Fatalf("Error reading config file: %v", err)
 	}
 	useReminders := config.DisableReminders
+	eventVisibility := config.EventVisibility
 
 	db, err := openDB(".gcalsync.db")
 	if err != nil {
@@ -40,7 +41,7 @@ func syncCalendars() {
 
 		for _, calendarID := range calendarIDs {
 			fmt.Printf("  ↪️ Syncing calendar: %s\n", calendarID)
-			syncCalendar(db, calendarService, calendarID, calendars, accountName, useReminders)
+			syncCalendar(db, calendarService, calendarID, calendars, accountName, useReminders, eventVisibility)
 		}
 		fmt.Println("✅ Calendar synchronization completed successfully!")
 	}
@@ -62,7 +63,7 @@ func getCalendarsFromDB(db *sql.DB) map[string][]string {
 	return calendars
 }
 
-func syncCalendar(db *sql.DB, calendarService *calendar.Service, calendarID string, calendars map[string][]string, accountName string, useReminders bool) {
+func syncCalendar(db *sql.DB, calendarService *calendar.Service, calendarID string, calendars map[string][]string, accountName string, useReminders bool, eventVisibility string) {
 	ctx := context.Background()
 	calendarService = tokenExpired(db, accountName, calendarService, ctx)
 	pageToken := ""
@@ -135,6 +136,10 @@ func syncCalendar(db *sql.DB, calendarService *calendar.Service, calendarID stri
 							}
 							if !useReminders {
 								blockerEvent.Reminders = nil
+							}
+
+							if eventVisibility != "" {
+								blockerEvent.Visibility = eventVisibility
 							}
 
 							var res *calendar.Event


### PR DESCRIPTION
Allowing for users to pick the Visibility setting for sync-ed events allows users to not disclose all the details to others who have default visibility access to one's calendars. Sycned events can be marked private.