### PR TITLE
Config file sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,13 @@ Say goodbye to calendar conflicts and hello to seamless synchronization. 🎉
 4. Create a `.gcalsync.toml` file in the project directory with your OAuth2 credentials:
 
     ```toml
-    client_id = "your-client-id"           # Your OAuth2 client ID
-    client_secret = "your-client-secret"   # Your OAuth2 client secret
+    [general]
     disable_reminders = false              # Disable reminders for blocker events
     block_event_visibility = "private"     # Visibility of blocker events (private, public, or default)
+
+    [google]
+    client_id = "your-client-id"           # Your OAuth2 client ID
+    client_secret = "your-client-secret"   # Your OAuth2 client secret
     ```
 
     Don't forget to choose the appropriate OAuth2 consent screen settings and [add the necessary scopes](https://developers.google.com/identity/oauth2/web/guides/get-google-api-clientid) for the Google Calendar API, also double check that you are select "Desktop app" as application type.
@@ -102,6 +105,36 @@ By default blocker events will inherit your default Google Calendar reminder/ale
 ### 🕶️ Setting Block Event Visibility
 
 By default blocker events will be created with the visibility set to "private". If you want to change the visibility of blocker events, you can set the `block_event_visibility` field to "public" or "default" in the `.gcalsync.toml` configuration file.
+
+### Configuration File
+
+The `.gcalsync.toml` configuration file is used to store OAuth2 credentials and general settings for the program. You can customize the settings to suit your preferences and needs. The file should be located in the project directory or `~/.config/gcalsync/` directory.
+
+At a minimum, the configuration file should contain the following fields:
+
+```toml
+[google]
+client_id = "your-client-id"
+client_secret = "your-client-secret"
+```
+Additional sections and fields can be added to configure the program behavior:
+
+```toml
+[general]
+block_event_visibility = "private"  # Keep O_o event public or private
+disable_reminders = true            # Set reminders on O_o events or not
+verbosity_level = 1                 # How much chatter to spill out when running sync
+```
+
+When support for other services will be added, the configuration file will be extended with additional sections, e.g. to include `[caldav]`, `[apple]`, and `[office365]`, e.g.:
+
+```toml
+[caldav]
+url = "https://example.com/calendar"
+username = "user"
+password = "password"
+```
+
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ disable_reminders = true            # Set reminders on O_o events or not
 verbosity_level = 1                 # How much chatter to spill out when running sync
 ```
 
-When support for other services will be added, the configuration file will be extended with additional sections, e.g. to include `[caldav]`, `[apple]`, and `[office365]`, e.g.:
+**When support for other services is added**, the configuration file will be extended with additional sections, e.g. to include `[caldav]`, `[apple]`, and `[office365]`, e.g.:
 
 ```toml
 [caldav]

--- a/backup.gcalsync.toml
+++ b/backup.gcalsync.toml
@@ -7,12 +7,3 @@ block_event_visibility = "private" # Keep O_o event public or private
 client_id = ""     # Get these from the Google Developer Console
 client_secret = "" # Get these from the Google Developer
 
-[caldav]
-url = ""      # URL of the CalDAV server
-username = "" # Username for the CalDAV server
-password = "" # Password for the CalDAV server
-
-[office365]
-client_id = ""     # Get these from the Azure Portal
-client_secret = "" # Get these from the Azure Portal
-tenant_id = ""     # Get these from the Azure Portal, make sure that the tenant has the correct permissions

--- a/backup.gcalsync.toml
+++ b/backup.gcalsync.toml
@@ -1,2 +1,18 @@
-client_id = ""
-client_secret = ""
+[general]
+disable_reminders = false          # Set reminders on O_o events or not
+verbosity_level = 1                # How much chatter to spill out when running sync 1 = errors only, 2 = info, 3 = debug
+block_event_visibility = "private" # Keep O_o event public or private
+
+[google]
+client_id = ""     # Get these from the Google Developer Console
+client_secret = "" # Get these from the Google Developer
+
+[caldav]
+url = ""      # URL of the CalDAV server
+username = "" # Username for the CalDAV server
+password = "" # Password for the CalDAV server
+
+[office365]
+client_id = ""     # Get these from the Azure Portal
+client_secret = "" # Get these from the Azure Portal
+tenant_id = ""     # Get these from the Azure Portal, make sure that the tenant has the correct permissions

--- a/cleanup.go
+++ b/cleanup.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"google.golang.org/api/calendar/v3"
+	"google.golang.org/api/option"
 )
 
 func cleanupCalendars() {
@@ -27,7 +28,7 @@ func cleanupCalendars() {
 
 	for accountName, calendarIDs := range calendars {
 		client := getClient(ctx, oauthConfig, db, accountName, config)
-		calendarService, err := calendar.New(client)
+		calendarService, err := calendar.NewService(ctx, option.WithHTTPClient(client))
 		if err != nil {
 			log.Fatalf("Error creating calendar client: %v", err)
 		}

--- a/common.go
+++ b/common.go
@@ -22,12 +22,34 @@ import (
 	"google.golang.org/api/option"
 )
 
-type Config struct {
-	ClientID         string `toml:"client_id"`
-	ClientSecret     string `toml:"client_secret"`
+type GoogleConfig struct {
+	ClientID     string `toml:"client_id"`
+	ClientSecret string `toml:"client_secret"`
+}
+
+type CalDavConfig struct {
+	URL      string `toml:"url"`
+	UserName string `toml:"username"`
+	Password string `toml:"password"`
+}
+
+type Office365Config struct {
+	ClientID     string `toml:"client_id"`
+	ClientSecret string `toml:"client_secret"`
+	ClientTenant string `toml:"tenant_id"`
+}
+
+type GeneralConfig struct {
 	DisableReminders bool   `toml:"disable_reminders"`
 	EventVisibility  string `toml:"block_event_visibility"`
 	AuthorizedPorts  []int  `toml:"authorized_ports"`
+}
+
+type Config struct {
+	General   GeneralConfig   `toml:"general"`
+	Google    GoogleConfig    `toml:"google"`
+	CalDav    CalDavConfig    `toml:"caldav"`
+	Office365 Office365Config `toml:"office365"`
 }
 
 var oauthConfig *oauth2.Config
@@ -35,8 +57,8 @@ var configDir string
 
 func initOAuthConfig(config *Config) {
 	oauthConfig = &oauth2.Config{
-		ClientID:     config.ClientID,
-		ClientSecret: config.ClientSecret,
+		ClientID:     config.Google.ClientID,
+		ClientSecret: config.Google.ClientSecret,
 		Endpoint:     google.Endpoint,
 		Scopes:       []string{calendar.CalendarScope},
 		// RedirectURL will be set dynamically in getTokenFromWeb
@@ -77,7 +99,7 @@ func openDB(filename string) (*sql.DB, error) {
 
 func getTokenFromWeb(config *oauth2.Config, cfg *Config) *oauth2.Token {
 	// Start local server
-	listener, err := findAvailablePort(cfg.AuthorizedPorts)
+	listener, err := findAvailablePort(cfg.General.AuthorizedPorts)
 	if err != nil {
 		log.Fatalf("Unable to start listener: %v", err)
 	}

--- a/common.go
+++ b/common.go
@@ -27,18 +27,6 @@ type GoogleConfig struct {
 	ClientSecret string `toml:"client_secret"`
 }
 
-type CalDavConfig struct {
-	URL      string `toml:"url"`
-	UserName string `toml:"username"`
-	Password string `toml:"password"`
-}
-
-type Office365Config struct {
-	ClientID     string `toml:"client_id"`
-	ClientSecret string `toml:"client_secret"`
-	ClientTenant string `toml:"tenant_id"`
-}
-
 type GeneralConfig struct {
 	DisableReminders bool   `toml:"disable_reminders"`
 	EventVisibility  string `toml:"block_event_visibility"`
@@ -47,10 +35,8 @@ type GeneralConfig struct {
 }
 
 type Config struct {
-	General   GeneralConfig   `toml:"general"`
-	Google    GoogleConfig    `toml:"google"`
-	CalDav    CalDavConfig    `toml:"caldav"`
-	Office365 Office365Config `toml:"office365"`
+	General GeneralConfig `toml:"general"`
+	Google  GoogleConfig  `toml:"google"`
 }
 
 var oauthConfig *oauth2.Config

--- a/sync.go
+++ b/sync.go
@@ -18,8 +18,8 @@ func syncCalendars() {
 	if err != nil {
 		log.Fatalf("Error reading config file: %v", err)
 	}
-	useReminders := config.DisableReminders
-	eventVisibility := config.EventVisibility
+	useReminders := config.General.DisableReminders
+	eventVisibility := config.General.EventVisibility
 
 	db, err := openDB(".gcalsync.db")
 	if err != nil {


### PR DESCRIPTION
Split up config file into sections:

 - `general` for general options, e.g. enable/disable reminders, event usability, etc.
 - `google` to keep Google OAuth parameters
 - `caldav` for future caldav options (e.g. server IRL, user, password)
 - `office365` for possible Office365 OAuth details (client and tenant id, secret)

Format check and converter added as part of `readConfig` function. `README.md` updates to follow. 

+ minor change in `cleanup.go` to use `NewService` instead of `New` when creating `calendarService`.